### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
             "properties": {
                 "material-icons.classList": {
                     "type": "string",
-                    "default": "material-icon",
+                    "default": "material-icons",
                     "description": "Defines classes of newly inserted svgs"
                 },
                 "material-icons.includeXmlns": {


### PR DESCRIPTION
The default class is missing the 's' at the end. 

Also, it would be nice to include in the docs that if using the font option that you need to include the link back to the Google Fonts stylesheet, or some sort of keybinding to insert it into the DOM:

&lt;link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">